### PR TITLE
Firm up partition definition

### DIFF
--- a/D3129_Views/tex/views.tex
+++ b/D3129_Views/tex/views.tex
@@ -190,7 +190,7 @@ Copyable descriptors are specializations of the descriptors that can be copied. 
 a vertex or edge reference. \tcode{copyable_vertex_t<G>} shows the simple definition.
 
 \begin{lstlisting}
-template <class VId, class VV>
+template <class VId, class VV=void>
 using copyable_vertex_t = vertex_descriptor<VId, void, VV>; // {id, value}
 \end{lstlisting}
 
@@ -201,9 +201,9 @@ using copyable_vertex_t = vertex_descriptor<VId, void, VV>; // {id, value}
 \hline
     \textbf{Type} & \textbf{Definition} \\
 \hline
-    \tcode{copyable_vertex_t<T,VId,VV>} & \tcode{vertex_descriptor<VId, void, VV>} \\
-    \tcode{copyable_edge_t<T,Vid,EV>} & \tcode{edge_descriptor<VId, true, void, EV>>} \\
-    \tcode{copyable_neighbor_t<Vid,VV>} & \tcode{neighbor_descriptor<VId, true, void, VV>} \\
+    \tcode{copyable_vertex_t<T,VId,VV=void>} & \tcode{vertex_descriptor<VId, void, VV>} \\
+    \tcode{copyable_edge_t<T,Vid,EV=void>} & \tcode{edge_descriptor<VId, true, void, EV>>} \\
+    \tcode{copyable_neighbor_t<Vid,VV=void>} & \tcode{neighbor_descriptor<VId, true, void, VV>} \\
 \hline
 \end{tabular}}
 \caption{Descriptor Concepts}
@@ -221,9 +221,9 @@ Given the copyable types, it's useful to have concepts to determine if a type is
 \hline
     \textbf{Concept} & \textbf{Definition} \\
 \hline
-    \tcode{copyable_vertex<T,VId,VV>} & \tcode{convertible_to<T, copyable_vertex_t<VId, VV>>} \\
-    \tcode{copyable_edge<T,Vid,EV>} & \tcode{convertible_to<T, copyable_edge_t<VId, EV>>} \\
-    \tcode{copyable_neighbor<T,Vid,VV>} & \tcode{convertible_to<T, copyable_neighbor_t<VId, VV>>} \\
+    \tcode{copyable_vertex<T,VId,VV=void>} & \tcode{convertible_to<T, copyable_vertex_t<VId, VV>>} \\
+    \tcode{copyable_edge<T,Vid,EV=void>} & \tcode{convertible_to<T, copyable_edge_t<VId, EV>>} \\
+    \tcode{copyable_neighbor<T,Vid,VV=void>} & \tcode{convertible_to<T, copyable_neighbor_t<VId, VV>>} \\
 \hline
 \end{tabular}}
 \caption{Descriptor Concepts}

--- a/D3130_Container_Interface/tex/container_interface.tex
+++ b/D3130_Container_Interface/tex/container_interface.tex
@@ -168,14 +168,14 @@ The type aliases are defined by either a function specialization for the underly
     \tcode{vertex_iterator_t<G>} & \tcode{iterator_t<vertex_range_t<G>>} & \\    
     \tcode{vertex_t<G>} & \tcode{range_value_t<vertex_range_t<G>>} & \\    
     \tcode{vertex_reference_t<G>} & \tcode{range_reference_t<vertex_range_t<G>>} & \\    
-    \tcode{vertex_id_t<G>} & \tcode{decltype(vertex_id(g))} & \\    
-    \tcode{vertex_value_t<G>} & \tcode{decltype(vertex_value(g))} & optional \\
+    \tcode{vertex_id_t<G>} & \tcode{decltype(vertex_id(g,ui))} & \\
+    \tcode{vertex_value_t<G>} & \tcode{decltype(vertex_value(g,u))} & optional \\
 \hline
     \tcode{vertex_edge_range_t<G>} & \tcode{decltype(edges(g,u))} & \\    
     \tcode{vertex_edge_iterator_t<G>} & \tcode{iterator_t<vertex_edge_range_t<G>>} & \\    
     \tcode{edge_t<G>} & \tcode{range_value_t<vertex_edge_range_t<G>>} & \\    
     \tcode{edge_reference_t<G>} & \tcode{range_reference_t<vertex_edge_range_t<G>>} & \\    
-    \tcode{edge_value_t<G>} & \tcode{decltype(edge_value(g))} & optional \\
+    \tcode{edge_value_t<G>} & \tcode{decltype(edge_value(g,uv))} & optional \\
 \hdashline
     \multicolumn{3}{c}{The following is only available when the optional \tcode{source_id(g,uv)} is defined for the edge} \\
 \hdashline

--- a/D3130_Container_Interface/tex/container_interface.tex
+++ b/D3130_Container_Interface/tex/container_interface.tex
@@ -181,9 +181,8 @@ The type aliases are defined by either a function specialization for the underly
 \hdashline
     \tcode{edge_id_t<G>} & \tcode{edge_descriptor<vertex_id_t<G>,true,void,void>} & \\    
 \hline
-    \tcode{partition_id_t<G>} & \tcode{decltype(partition_id(g,u))} & optional \\
+    \tcode{partition_id_t<G>} & \tcode{decltype(partition_id(g,uid))} & optional \\
     \tcode{partition_vertex_range_t<G>} & \tcode{vertices(g,pid)} & optional \\    
-    \tcode{partition_edge_range_t<G>} & \tcode{edges(g,u,pid)} & optional \\    
 \hline
 \end{tabular}}
 \caption{Graph Container Interface Type Aliases}
@@ -220,10 +219,10 @@ to be able to reflect all forms of adjacency graphs including a vector of lists,
     \tcode{graph_value(g)} & \tcode{graph_value_t<G>} & constant & n/a, optional \\
     \tcode{vertices(g)} & \tcode{vertex_range_t<G>} & constant & \tcode{g} if \tcode{random_access_range<G>}, n/a otherwise \\
     \tcode{num_vertices(g)} & \tcode{integral} & constant & \tcode{size(vertices(g))} \\
-    \tcode{num_edges(g)} & \tcode{integral} & constant to |E| & \tcode{n=0; for(u: vertices(g)) n+=distance(edges(g,u)); return n;} \\
-    \tcode{has_edge(g)} & \tcode{bool} & contant to |V| & \tcode{for(u: vertices(g)) if !empty(edges(g,u)) return true; return false;} \\
+    \tcode{num_edges(g)} & \tcode{integral} & |E| & \tcode{n=0; for(u: vertices(g)) n+=distance(edges(g,u)); return n;} \\
+    \tcode{has_edge(g)} & \tcode{bool} & |V| & \tcode{for(u: vertices(g)) if !empty(edges(g,u)) return true; return false;} \\
 \hdashline
-    \tcode{partition_count(g)} & \tcode{vertex_id_t<G>} & constant & 1 \\
+    \tcode{num_partitions(g)} & \tcode{integral} & constant & 1 \\
     \tcode{vertices(g,pid)} & \tcode{partition_vertex_range_t<G>} & constant & \tcode{vertices(g)} \\
     \tcode{num_vertices(g,pid)} & \tcode{integral} & constant & \tcode{size(vertices(g))}  \\
 \hline
@@ -232,7 +231,11 @@ to be able to reflect all forms of adjacency graphs including a vector of lists,
 \label{tab:graph_func}
 \end{center}
 \end{table}
-The complexity of \tcode{num_edges(g)} and \tcode{has_edge(g)} is dependent on the underlying graph container's capabilities.
+The complexity shown above for \tcode{num_edges(g)} and \tcode{has_edge(g)} is for the default implementation. 
+Specific graph implementations may have better characteristics.
+
+The complexity shown above for \tcode{vertices(g,pid)} and \tcode{num_vertices(g,pid)} is for the default
+implementation. Specific graph implementations may have different characteristics.
 
 \begin{table}[h!]
 \begin{center}
@@ -252,10 +255,7 @@ The complexity of \tcode{num_edges(g)} and \tcode{has_edge(g)} is dependent on t
     \tcode{edges(g,u)} & \tcode{vertex_edge_range_t<G>} & constant & \tcode{u} if \tcode{forward range<vertex_t<G>>}, n/a otherwise \\
     \tcode{edges(g,uid)} & \tcode{vertex_edge_range_t<G>} & constant & \tcode{edges(g,*find_vertex(g,uid))} \\
 \hdashline
-    \tcode{partition_id(g,u)} & \tcode{partition_id_t<G>} & constant & 0 \\
-    \tcode{partition_id(g,uid)} & \tcode{partition_id_t<G>} & constant & \tcode{partition_id(g,*find_vertex(g,uid))} \\
-    \tcode{edges(g,u,pid)} & \tcode{partition_edge_range_t<G>} & linear & \tcode{edges(g,u)} \\
-    \tcode{edges(g,uid,pid)} & \tcode{partition_edge_range_t<G>} & linear & \tcode{edges(g,uid)} \\
+    \tcode{partition_id(g,uid)} & \tcode{partition_id_t<G>} & constant & 0 \\
 \hline
 \end{tabular}}
 \caption{Vertex Functions}
@@ -324,11 +324,11 @@ expose the vertices as a range.
 
 \section{Unipartite, Bipartite and Multipartite Graph Representation}
 
-\tcode{partition_count(g)} returns the number of partitions, or partiteness, of the graph. It has a range of 1 to n, where 1 identifies 
+\tcode{num_partitions(g)} returns the number of partitions, or partiteness, of the graph. It has a range of 1 to n, where 1 identifies 
 a unipartite graph, 2 is a bipartite graph, and a value of 2 or more can be considered a multipartite graph. 
 
 If a graph data structure doesn't support partitions then it is unipartite with one partition and partite functions will reflect that. 
-For instance, \tcode{partition_count(g)} returns a value of 1, and \tcode{vertices(g,0)} (vertices in the first partition) will return a range that includes all vertices in the graph.
+For instance, \tcode{num_partitions(g)} returns a value of 1, and \tcode{vertices(g,0)} (vertices in the first partition) will return a range that includes all vertices in the graph.
 
 A partition identifies a type of a vertex, where the vertex value types are assumed to be uniform in each partition. This creates a dilemma because 
 the existing \tcode{vertex_value(g,u)} returns a single type based template parameter for the vertex value type. Supporting 
@@ -347,55 +347,6 @@ determine how to get the appropriate value.
 
 \tcode{edges(g,uid,pid)} and \tcode{edges(g,ui,pid)} filter the edges where the target is in the partition \tcode{pid} passed.
 This isn't needed for bipartite graphs.
-
-\section{Loading Graph Data}
-
-The \tcode{load} functions are used to load vertex and edge data into a graph. They may throw a \tcode{graph_error} exception.
-
-All graph data structures need to implement \tcode{load_graph}, \tcode{load_vertices} and \tcode{load_edges}. 
-Whether \tcode{load_vertices} or \tcode{load_edges} can be called multiple times, or after \tcode{load_graph} is called, is dependent on the underlying graph data structure.
-\tcode{load_partition} only needs to be implemented if a graph supports partitions.
-
-Projections are used to convert values in the input range to the expected copyable type. In the following \tcode{load_vertices} 
-prototype, \tcode{vproj(ranges::range_value_t<VRng>&)} $\rightarrow$ \tcode{vertex_descriptor<vertex_id_t<G>, vertex_value_t<G>>}.
-If there is no vertex value stored in the graph then \tcode{vertex_value_t<G>} will be \tcode{void} and the resulting 
-\tcode{vertex_descriptor} will have a single id member. If \tcode{vproj(ranges::range_value_t<VRng>&)} is the same as
-\tcode{vertex_descriptor<vertex_id_t<G>, vertex_value_t<G>>} then \tcode{VProj = identity} can be used.
-
-\begin{lstlisting}
-template <adjacency_list G, ranges::forward_range VRng, class VProj = identity>
-requires copyable_vertex<invoke_result<VProj, ranges::range_value_t<VRng>>,
-                         vertex_id_t<G>, vertex_value_t<G>>
-constexpr void load_vertices(G&, const VRng& vrng, VProj vproj);
-\end{lstlisting}
-
-The same pattern is applied using \tcode{ERng} and \tcode{EProj} for edges.
-
-For graphs with vertex values, \tcode{load_vertices} should be called before \tcode{load_edges}.
-
-Whether \tcode{load_vertices} or \tcode{load_edges} can be called multiple times is graph-dependent.
-
-For graphs with partititions, \tcode{load_partition} must be called to load vertices for each 
-partition \tcode{pid}. \tcode{pid} values must be contiguous and their vertices should be loaded
-contiguously. \tcode{empty(vrng)} may be empty if there are no vertices in the partition. 
-
-\begin{table}[h!]
-\begin{center}
-\resizebox{\textwidth}{!}
-{\begin{tabular}{l l p{1.5cm} L{7.0cm}}
-\hline
-    \textbf{Function} & \textbf{Return Type} & \textbf{Complexity} & \textbf{Default Implementation} \\
-\hline
-    \tcode{load_graph(g, erng, vrng, eproj=identity(), vproj=identity())} & void & V + E & n/a \\
-    \tcode{load_vertices(g, vrng, vproj=identity())} & void & V & n/a \\
-    \tcode{load_partition(g, pid, vrng, vproj=identity())} & void & V(p) & \tcode{load_vertices} is called if partitions are not supported; there will be a single partition. \\
-    \tcode{load_edges(g, erng, eproj=identity(), vertex_count=0)} & void & E & n/a \\
-\hline
-\end{tabular}}
-\caption{Graph Load Functions}
-\label{tab:load_func}
-\end{center}
-\end{table}
 
 \section{Edgelists}
 An edgelist is a range of \tcode{edge_descriptor} values, used by some algorithms. Examples include the \tcode{edgelist} adjacency 

--- a/D3130_Container_Interface/tex/revision.tex
+++ b/D3130_Container_Interface/tex/revision.tex
@@ -14,6 +14,10 @@
             Container Implementation paper.
       \item Identify all \tcode{concept} definitions as "For exposition only" until we have consensus of whether they 
             belong in the standard or not.
+      \item Revised partition functions after implementation to reflect usage, including: renaming \tcode{partition_count(g)} 
+            to \tcode{num_partitions(g)} to match other names used, changed \tcode{partition_id(g,u)} to \tcode{partition_id(g,uid)}
+            because vertices may not exist when the function is called, and removing \tcode{partition_vertex_edge_range_t} and 
+            \tcode{edges(g,u,pid)} because they don't add much value and may limit future type-based designs.
 \end{itemize}
 
 \subsection*{\paperno r1}
@@ -21,4 +25,8 @@
 \begin{itemize}
       \item Add \tcode{num_edges(g)} and \tcode{has_edge(g)} functions. Split function table into 3 tables for graph,
             vertex and edge functions because it was getting too big.
+      \item Removed the Load Graph Data section with it's load functions from \href{https://www.wg21.link/P3130}{P3130 Graph Container Interface}
+            because it unnecessarily complicates the interface with constructors for graph data structures. To complement this, constructors have 
+            been added for \tcode{compressed_graph} in \href{https://www.wg21.link/P3131}{P3131 Graph Containers}. An optional \tcode{part_start_ids} 
+            parameter has also been added to constructors to identify the first vertex id of each partition for multi-partite graphs.
 \end{itemize}

--- a/D3131_Containers/src/compressed_graph.hpp
+++ b/D3131_Containers/src/compressed_graph.hpp
@@ -1,0 +1,108 @@
+template <class EV, 
+          class VV, 
+          class GV, 
+          integral VId=uint32_t, 
+          integral EIndex=uint32_t, 
+          class    Alloc=allocator<VId>>
+class compressed_graph {
+public: // Construction/Destruction/Assignment
+  constexpr compressed_graph()                        = default;
+  constexpr compressed_graph(const compressed_graph&) = default;
+  constexpr compressed_graph(compressed_graph&&)      = default;
+  constexpr ~compressed_graph()                       = default;
+
+  constexpr compressed_graph& operator=(const compressed_graph&) = default;
+  constexpr compressed_graph& operator=(compressed_graph&&)      = default;
+
+  // compressed\_graph(      alloc)
+  // compressed\_graph(gv\&,  alloc)
+  // compressed\_graph(gv\&\&, alloc)
+
+  constexpr compressed_graph(const Alloc& alloc);
+  constexpr compressed_graph(const graph_value_type& value, const Alloc& alloc = Alloc());
+  constexpr compressed_graph(graph_value_type&& value, const Alloc& alloc = Alloc());
+
+  // compressed\_graph(erng, eprojection, alloc)
+  // compressed\_graph(gv\&,  erng, eprojection, alloc)
+  // compressed\_graph(gv\&\&, erng, eprojection, alloc)
+
+  template <ranges::forward_range ERng, ranges::forward_range PartRng, class EProj = identity>
+  requires copyable_edge<invoke_result<EProj, ranges::range_value_t<ERng>>, VId, EV> &&
+           convertible_to<ranges::range_value_t<PartRng>, VId>
+  constexpr compressed_graph(const ERng&    erng,
+                             EProj          eprojection,
+                             const PartRng& part_start_ids = vector<VId>(),
+                             const Alloc&   alloc          = Alloc());
+
+  template <ranges::forward_range ERng, ranges::forward_range PartRng, class EProj = identity>
+  requires copyable_edge<invoke_result<EProj, ranges::range_value_t<ERng>>, VId, EV> &&
+                 convertible_to<ranges::range_value_t<PartRng>, VId>
+  constexpr compressed_graph(const graph_value_type& value,
+                             const ERng&             erng,
+                             EProj                   eprojection,
+                             const PartRng&          part_start_ids = vector<VId>(),
+                             const Alloc&            alloc          = Alloc());
+
+  template <ranges::forward_range ERng, ranges::forward_range PartRng, class EProj = identity>
+  requires copyable_edge<invoke_result<EProj, ranges::range_value_t<ERng>>, VId, EV> &&
+                 convertible_to<ranges::range_value_t<PartRng>, VId>
+  constexpr compressed_graph(graph_value_type&& value,
+                             const ERng&        erng,
+                             EProj              eprojection,
+                             const PartRng&     part_start_ids = vector<VId>(),
+                             const Alloc&       alloc          = Alloc());
+
+  // compressed\_graph(erng, vrng, eprojection, vprojection, alloc)
+  // compressed\_graph(gv\&,  erng, vrng, eprojection, vprojection, alloc)
+  // compressed\_graph(gv\&\&, erng, vrng, eprojection, vprojection, alloc)
+
+  template <ranges::forward_range ERng,
+            ranges::forward_range VRng,
+            ranges::forward_range PartRng,
+            class EProj = identity,
+            class VProj = identity>
+  requires copyable_edge<invoke_result<EProj, ranges::range_value_t<ERng>>, VId, EV> &&
+           copyable_vertex<invoke_result<VProj, ranges::range_value_t<VRng>>, VId, VV> &&
+           convertible_to<ranges::range_value_t<PartRng>, VId>
+  constexpr compressed_graph(const ERng&    erng,
+                             const VRng&    vrng,
+                             EProj          eprojection    = {},
+                             VProj          vprojection    = {},
+                             const PartRng& part_start_ids = vector<VId>(),
+                             const Alloc&   alloc          = Alloc());
+
+  template <ranges::forward_range ERng,
+            ranges::forward_range VRng,
+            ranges::forward_range PartRng,
+            class EProj = identity,
+            class VProj = identity>
+  requires copyable_edge<invoke_result<EProj, ranges::range_value_t<ERng>>, VId, EV> &&
+                 copyable_vertex<invoke_result<VProj, ranges::range_value_t<VRng>>, VId, VV> &&
+                 convertible_to<ranges::range_value_t<PartRng>, VId>
+  constexpr compressed_graph(const graph_value_type& value,
+                             const ERng&             erng,
+                             const VRng&             vrng,
+                             EProj                   eprojection    = {},
+                             VProj                   vprojection    = {},
+                             const PartRng&          part_start_ids = vector<VId>(),
+                             const Alloc&            alloc          = Alloc());
+
+  template <ranges::forward_range ERng,
+            ranges::forward_range VRng,
+            ranges::forward_range PartRng,
+            class EProj = identity,
+            class VProj = identity>
+  requires copyable_edge<invoke_result<EProj, ranges::range_value_t<ERng>>, VId, EV> &&
+                 copyable_vertex<invoke_result<VProj, ranges::range_value_t<VRng>>, VId, VV> &&
+                 convertible_to<ranges::range_value_t<PartRng>, VId>
+  constexpr compressed_graph(graph_value_type&& value,
+                             const ERng&        erng,
+                             const VRng&        vrng,
+                             EProj              eprojection    = {},
+                             VProj              vprojection    = {},
+                             const PartRng&     part_start_ids = vector<VId>(),
+                             const Alloc&       alloc          = Alloc());
+
+  constexpr compressed_graph(const initializer_list<copyable_edge_t<VId, EV>>& ilist, 
+                             const Alloc& alloc = Alloc());
+};

--- a/D3131_Containers/src/compressed_graph_gvoid.hpp
+++ b/D3131_Containers/src/compressed_graph_gvoid.hpp
@@ -1,0 +1,40 @@
+template <class EV, 
+          class VV, 
+          integral VId=uint32_t, 
+          integral EIndex=uint32_t, 
+          class    Alloc=allocator<VId>>
+template <class EV, class VV, integral VId, integral EIndex, class Alloc>
+class compressed_graph<EV, VV, void, VId, EIndex, Alloc>
+public: // Construction/Destruction
+  constexpr compressed_graph()                        = default;
+  constexpr compressed_graph(const compressed_graph&) = default;
+  constexpr compressed_graph(compressed_graph&&)      = default;
+  constexpr ~compressed_graph()                       = default;
+
+  constexpr compressed_graph& operator=(const compressed_graph&) = default;
+  constexpr compressed_graph& operator=(compressed_graph&&)      = default;
+
+  // edge-only construction
+  template <ranges::forward_range ERng, class EProj = identity>
+  requires copyable_edge<invoke_result<EProj, ranges::range_value_t<ERng>>, VId, EV>
+  constexpr compressed_graph(const ERng& erng, 
+                             EProj eprojection = identity(), 
+                             const Alloc& alloc = Alloc());
+
+  // edge and vertex value construction
+  template <ranges::forward_range ERng,
+            ranges::forward_range VRng,
+            ranges::forward_range PartRng,
+            class EProj = identity,
+            class VProj = identity>
+  constexpr compressed_graph(const ERng&    erng,
+                             const VRng&    vrng,
+                             EProj          eprojection    = {},
+                             VProj          vprojection    = {},
+                             const PartRng& part_start_ids = vector<VId>(),
+                             const Alloc&   alloc          = Alloc());
+
+  // initializer list using edge\_descriptor<VId,true,void,EV>
+  constexpr compressed_graph(const initializer_list<copyable_edge_t<VId, EV>>& ilist, 
+                             const Alloc& alloc = Alloc());
+};

--- a/D3131_Containers/tex/containers.tex
+++ b/D3131_Containers/tex/containers.tex
@@ -2,63 +2,65 @@
 \clearpage
 %% \chapter{Graph Container Implementations}
 
-\section{compressed\_graph}
+\section{compressed\_graph Graph Container}
 \tcode{compressed_graph} is a graph container being proposed for the standard library. It is a high-performance data structure that 
 uses \href{https://en.wikipedia.org/wiki/Sparse_matrix#Compressed_sparse_row_\%28CSR\%2C_CRS_or_Yale_format\%29}{Compressed Sparse Row} 
-format to store its vertices, edges and associated values. Once constructed, vertices and edges cannot be added or deleted but values 
-on vertices and edges can be modified.
+(CSR) format to store its vertices, edges and associated values. Once constructed, vertices and edges cannot be added or deleted 
+but values on vertices and edges can be modified.
 
-The following listing shows the prototype for the \tcode{compressed_graph}. Only the members shown for \tcode{compressed_graph} are public. 
-No other member functions or types are exposed as part of the standard. All other types are only accessible through the types and functions 
-in the Graph Container Interface. Multiple partitions (multi-partite) can be defined by passing the number of partitions in a constructor.
+There are a number of features added beyond the typical CSR implmentation:
+\begin{itemize}
+    \item   \textbf{User-defined values} Values can be associated with edge, vertices and and the graph itself by defining the 
+            \tcode{EV}, \tcode{VV}, and \tcode{GV} template arguments respectively. If the type is void, no memory overhead is 
+            incurred.
+    \item   \textbf{Index type sizes} The size of the integral indexes into the internal row and column structures can be controlled
+            by the \tcode{VId} and \tcode{EIndex} template arguments respectively to give a balance between storage and performance.
+    \item   \textbf{Multi-partite graphs} The vertices can optionally be partitioned into multiple partitions by passing the 
+            starting vertex id of each partition in the \tcode{part_start_ids} parameter in the constructors.
+\end{itemize}
+
+The following listings shows the prototype for the \tcode{compressed_graph} when the graph value type \tcode{GV} is non-\tcode{void} and a 
+class template specialization when it is \tcode{void}.
+
+Only the constuctors shown for \tcode{compressed_graph} are public. All other types or functions are only accessible through the types 
+and functions in the Graph Container Interface.
 
 \begin{table}[h]
     \setcellgapes{3pt}
     \makegapedcells
     \centering
-    \begin{tabular}{|P{0.37\textwidth}|P{0.25\textwidth}|P{0.38\textwidth}|}
+    \begin{tabular}{|P{0.38\textwidth}|P{0.35\textwidth}|P{0.25\textwidth}|}
     \hline
-    \textbf{Implements \tcode{load_graph}?} Yes & \textbf{Append vertices?} No & \textbf{vertex\_id assignment:} Contiguous\\
-    \textbf{Implements \tcode{load_vertices}?} Yes & \textbf{Append edges?} No & \textbf{Vertices range:} Contiguous \\
-    \textbf{Implements \tcode{load_edges}?} Yes &  & \textbf{Edge range:} Contiguous \\
-    \textbf{Implements \tcode{load_partition}?} Yes &  & \\
+    \textbf{vertex\_id assignment:} Contiguous & \textbf{\tcode{has_edge(g)}} $O(1)$ & \textbf{Append vertices?} No \\
+    \textbf{Vertices range:} Contiguous & \textbf{\tcode{num_edges(g)}} $O(1)$ & \textbf{Append edges?} No \\
+    \textbf{Edge range:} Contiguous & \textbf{\tcode{partition_id(g,uid)}} $O(log(P+1))$ & \textbf{Partions?} Yes\\
+    %O(log(P+1)) is the complexity of std::upper_bound; +1 is for the number of vertices added at the end of partition_start_ids
     \hline
     \end{tabular}
     %\caption{Jaccard Coefficient Summary}
     \label{tab:compressed_graph_summary}
 \end{table}
-
-\begin{lstlisting}
-template <class    EV     = void,     // Edge Value type
-          class    VV     = void,     // Vertex Value type
-          class    GV     = void,     // Graph Value type
-          integral VId    = uint32_t, // vertex id type
-          integral EIndex = uint32_t, // edge index type
-          class    Alloc  = allocator<VId>> // for internal containers
-class compressed_graph {
-public:
-    compressed_graph();
-    explicit compressed_graph(size_t num_partitions); // multi-partite
-    compressed_graph(const compressed_graph&);
-    compressed_graph(compressed_graph&&);
-    {tilde}compressed_graph();
-
-    compressed_graph& operator=(const compressed_graph&);
-    compressed_graph& operator=(compressed_graph&&);
-}
-\end{lstlisting}
-
-
-\phil{Additional members to define?}
+Note: $P$ is the number of partitions. It has a minimum of 1 for a unipartite graph, and is exepected to be small for all
+reasonable cases.
 
 \phil{tilde in destructor is giving problems in latex}
 
 \phil{What is allowed/required for EV, VV, GV? Default constructible, ...? Create concept, or describe in mandates or preconditions. Use tuple value as starting point.}
 
+\subsection{compressed\_graph when \tcode{GV} is not \tcode{void}}
+{\small
+      \lstinputlisting{D3131_Containers/src/compressed_graph.hpp}
+}
+
 \begin{itemdescr}
     \pnum\mandates
         \begin{itemize}
-            \item Vertices and edges cannot be appended to an existing partition in an existing graph, but they can be added to a new partition.
+            \item The \tcode{EProj} template argument must be a projection that returns a value of \tcode{copyable_edge<VId, true, EV>} type
+                  given a value of \tcode{erng}. If the value type of \tcode{Erng} is already a \tcode{copyable_edge<VId, true, EV>} type, 
+                  then \tcode{EProj} can be \tcode{identity}.
+            \item The \tcode{VProj} template argument must be a projection that returns a value of \tcode{copyable_vertex<VId, VV>} type,
+                  given a value of \tcode{vrng}. If the value type of \tcode{Vrng} is already a \tcode{copyable_vertex<VId, VV>} type, 
+                  then \tcode{VProj} can be \tcode{identity}.
         \end{itemize}
     \pnum\preconditions
         \begin{itemize}
@@ -66,6 +68,11 @@ public:
                   number of vertices in the graph. The size of this type impacts the size of the \textit{edges}.
             \item The \tcode{EIndex} template argument must be able to store a value of |E|+1, where |E| is the
                   number of edges in the graph. The size of this type impact the size of the \textit{vertices}.
+            \item The \tcode{EProj} and \tcode{VProj} template arguments must be valid projections.
+            \item The \tcode{part_start_ids} range includes the starting vertex id for each partition. If it is empty, then the graph is single-partite
+                    and the number of partitions is 1. If it is not empty, then the number of partitions is the size of the range, where the first element
+                    must be 0 and all remaining elements must be in ascending order, and not exceed the number of vertices in the graph. Any
+                    violation of these conditions results in undefined behavior.
         \end{itemize}
     \pnum\effects
         \begin{itemize}
@@ -85,6 +92,13 @@ public:
 %\pnum\errors
 \end{itemdescr}
 
+\subsection{compressed\_graph specialization when \tcode{GV} is \tcode{void}}
+When \tcode{GV} is void the number of constructors decreases significantly as shown in the following listing.
+It is a strict subset so there is no need to repeat the mandates, preconditions, effects, and remarks.
+
+{\small
+      \lstinputlisting{D3131_Containers/src/compressed_graph_gvoid.hpp}
+}
 
 \section{Using Existing Graph Data Structures}
 Reasonable defaults have been defined for the GCI functions to minimize the amount of work
@@ -166,7 +180,7 @@ When they are defined they must be in the same namespace as the data structures.
     \hline
         \multicolumn{2}{c}{When the graph supports multiple partitions} \\
     \hdashline
-        \tcode{partition_count(g)} & \\
+        \tcode{num_partitions(g)} & \\
         \tcode{partition_id(g,u)} & \\
         \tcode{vertices(g,u,pid)} & \\
     \hline
@@ -175,4 +189,3 @@ When they are defined they must be in the same namespace as the data structures.
     \label{tab:cmn_cpo_overrides}
     \end{center}
 \end{table}
-

--- a/D3131_Containers/tex/revision.tex
+++ b/D3131_Containers/tex/revision.tex
@@ -15,4 +15,9 @@
 \subsection*{\paperno r1}
 \begin{itemize}
       \item Added complexity for \tcode{num_edges(g)} and \tcode{has_edge(g)} functions in \tcode{compressed_graph}.
+      \item Removed the Load Graph Data section with it's load functions from \href{https://www.wg21.link/P3130}{P3130 Graph Container Interface}
+            because it unnecessarily complicates the interface with constructors for graph data structures. To complement this, constructors have 
+            been added for \tcode{compressed_graph} in \href{https://www.wg21.link/P3131}{P3131 Graph Containers}. An optional \tcode{part_start_ids} 
+            parameter has also been added to constructors to identify the first vertex id of each partition for multi-partite graphs.
+      \item Added feature summary of \tcode{compressed_graph} beyond the typical CSR implementation.
 \end{itemize}

--- a/tex/conventions.tex
+++ b/tex/conventions.tex
@@ -1,3 +1,5 @@
+\clearpage
+
 \section{Naming Conventions}
 
 Table~\ref{tab:name_conv} shows the naming conventions used throughout the Graph Library documents.
@@ -35,12 +37,9 @@ Table~\ref{tab:name_conv} shows the naming conventions used throughout the Graph
      \tcode{EI}         & \tcode{vertex_edge_iterator_t<G>} & \tcode{uvi,vwi}      & Edge Iterator for an edge of a vertex. \tcode{uvi} is an iterator for an edge from vertices \tcode{u} to \tcode{v}. \tcode{vwi} is an iterator for an edge from vertices \tcode{v} to \tcode{w}. \\
      \tcode{EVF}        &                                   & \tcode{evf}          & Edge Value Function: evf(uv) $\rightarrow$ edge value, or evf(eid) $\rightarrow$ edge value, depending on the requirements of the consuming algorithm or view.                                   \\
      \tcode{EProj}      &                                   & \tcode{eproj}        & Edge descriptor projection function: \tcode{eproj(x)} $\rightarrow$ \tcode{edge_descriptor<VId,Sourced,EV>}.                                                                                     \\
-     \hdashline
-     \tcode{PER}        & \tcode{partition_edge_range_t<G>} &                      & Partition Edge Range for edges of a partition vertex.                                                                                                                                            \\
      \hline
   \end{tabular}}
     \caption{Naming Conventions for Types and Variables}
     \label{tab:name_conv}
   \end{center}
 \end{table}
-


### PR DESCRIPTION
Remove load functions (recommendation from Oliver)

Remove unnecessary edges(g,u,pid) function and related types. It's just a filter based on target vertex partition, and can easily be done using facilities in the library. 

Add constructors for compressed_graph and include optional part_start_id parameter for partition definition.

Added implementation in graph-v2.
