### PR TITLE
D3128: add allocator parameters to algorithm synopses and documentation

### DIFF
--- a/D3128_Algorithms/src/breadth_first_search.hpp
+++ b/D3128_Algorithms/src/breadth_first_search.hpp
@@ -1,5 +1,7 @@
-template <adjacency_list G, class Visitor = empty_visitor>
+template <adjacency_list G, class Visitor = empty_visitor,
+          class Alloc = allocator<byte>>
 void breadth_first_search(
-      G&&            g,            // graph
-      vertex_id_t<G> source,       // starting vertex\_id
-      Visitor&&      visitor = empty_visitor())
+      G&&             g,            // graph
+      vertex_id_t<G>  source,       // starting vertex\_id
+      Visitor&&       visitor = empty_visitor(),
+      const Alloc&    alloc   = Alloc())

--- a/D3128_Algorithms/src/breadth_first_search_multi.hpp
+++ b/D3128_Algorithms/src/breadth_first_search_multi.hpp
@@ -1,5 +1,7 @@
-template <adjacency_list G, input_range Sources, class Visitor = empty_visitor>
+template <adjacency_list G, input_range Sources, class Visitor = empty_visitor,
+          class Alloc = allocator<byte>>
 requires convertible_to<range_value_t<Sources>, vertex_id_t<G>>
 void breadth_first_search(G&&            g, // graph
                           const Sources& sources,
-                          Visitor&&      visitor = empty_visitor())
+                          Visitor&&      visitor = empty_visitor(),
+                          const Alloc&   alloc   = Alloc())

--- a/D3128_Algorithms/src/connected_components.hpp
+++ b/D3128_Algorithms/src/connected_components.hpp
@@ -1,22 +1,22 @@
 /*
  * Hopcroft-Tarjan Articulation Points
  */
-template <adjacency_list G, class Iter>
+template <adjacency_list G, class Iter, class Alloc = allocator<byte>>
 requires output_iterator<Iter, vertex_id_t<G>>
-void articulation_points(G&& g, Iter cut_vertices);
+void articulation_points(G&& g, Iter cut_vertices, const Alloc& alloc = Alloc());
 
 /*
  * Hopcroft-Tarjan Biconnected Components
  */
-template <adjacency_list G, class OuterContainer>
-void biconnected_components(G&& g, OuterContainer& components);
+template <adjacency_list G, class OuterContainer, class Alloc = allocator<byte>>
+void biconnected_components(G&& g, OuterContainer& components, const Alloc& alloc = Alloc());
 
 /*
  * Connected Components
  */
-template <adjacency_list G, class ComponentFn>
+template <adjacency_list G, class ComponentFn, class Alloc = allocator<byte>>
 requires vertex_property_fn_for<ComponentFn, G>
-size_t connected_components(G&& g, ComponentFn&& component);
+size_t connected_components(G&& g, ComponentFn&& component, const Alloc& alloc = Alloc());
 
 /*
  * Afforest Connected Components
@@ -32,10 +32,12 @@ void afforest(G&& g, GT&& g_t, Component& component, const size_t neighbor_round
 /*
  * Kosaraju Strongly Connected Components
  */
-template <adjacency_list G, adjacency_list GT, class ComponentFn>
+template <adjacency_list G, adjacency_list GT, class ComponentFn,
+          class Alloc = allocator<byte>>
 requires vertex_property_fn_for<ComponentFn, G>
-void kosaraju(G&& g, GT&& g_t, ComponentFn&& component);
+void kosaraju(G&& g, GT&& g_t, ComponentFn&& component, const Alloc& alloc = Alloc());
 
-template <bidirectional_adjacency_list G, class ComponentFn>
+template <bidirectional_adjacency_list G, class ComponentFn,
+          class Alloc = allocator<byte>>
 requires vertex_property_fn_for<ComponentFn, G>
-void kosaraju(G&& g, ComponentFn&& component);
+void kosaraju(G&& g, ComponentFn&& component, const Alloc& alloc = Alloc());

--- a/D3128_Algorithms/src/depth_first_search.hpp
+++ b/D3128_Algorithms/src/depth_first_search.hpp
@@ -1,5 +1,7 @@
-template <adjacency_list G, class Visitor = empty_visitor>
+template <adjacency_list G, class Visitor = empty_visitor,
+          class Alloc = allocator<byte>>
 void depth_first_search(
-      G&&            g,            // graph
-      vertex_id_t<G> source,       // starting vertex\_id
-      Visitor&&      visitor = empty_visitor())
+      G&&             g,            // graph
+      vertex_id_t<G>  source,       // starting vertex\_id
+      Visitor&&       visitor = empty_visitor(),
+      const Alloc&    alloc   = Alloc())

--- a/D3128_Algorithms/src/dijkstra_shortest_dists.hpp
+++ b/D3128_Algorithms/src/dijkstra_shortest_dists.hpp
@@ -4,7 +4,8 @@ template <adjacency_list G,
                                                                        const edge_t<G>&)>,
           class Visitor = empty_visitor,
           class Compare = less<distance_fn_value_t<DistanceFn, G>>,
-          class Combine = plus<distance_fn_value_t<DistanceFn, G>>>
+          class Combine = plus<distance_fn_value_t<DistanceFn, G>>,
+          class Alloc   = allocator<byte>>
 requires distance_fn_for<DistanceFn, G> &&
          basic_edge_weight_function<G, WF, distance_fn_value_t<DistanceFn, G>, Compare, Combine>
 constexpr void dijkstra_shortest_distances(
@@ -15,4 +16,5 @@ constexpr void dijkstra_shortest_distances(
                        const edge_t<G>& uv) { return distance_fn_value_t<DistanceFn, G>(1); },
       Visitor&&             visitor = empty_visitor(),
       Compare&&             compare = less<distance_fn_value_t<DistanceFn, G>>(),
-      Combine&&             combine = plus<distance_fn_value_t<DistanceFn, G>>());
+      Combine&&             combine = plus<distance_fn_value_t<DistanceFn, G>>(),
+      const Alloc&          alloc   = Alloc());

--- a/D3128_Algorithms/src/dijkstra_shortest_dists_multi.hpp
+++ b/D3128_Algorithms/src/dijkstra_shortest_dists_multi.hpp
@@ -5,7 +5,8 @@ template <adjacency_list G,
                                                                        const edge_t<G>&)>,
           class Visitor = empty_visitor,
           class Compare = less<distance_fn_value_t<DistanceFn, G>>,
-          class Combine = plus<distance_fn_value_t<DistanceFn, G>>>
+          class Combine = plus<distance_fn_value_t<DistanceFn, G>>,
+          class Alloc   = allocator<byte>>
 requires distance_fn_for<DistanceFn, G> &&
          convertible_to<range_value_t<Sources>, vertex_id_t<G>> &&
          basic_edge_weight_function<G, WF, distance_fn_value_t<DistanceFn, G>, Compare, Combine>
@@ -17,4 +18,5 @@ constexpr void dijkstra_shortest_distances(
                        const edge_t<G>& uv) { return distance_fn_value_t<DistanceFn, G>(1); },
       Visitor&&      visitor = empty_visitor(),
       Compare&&      compare = less<distance_fn_value_t<DistanceFn, G>>(),
-      Combine&&      combine = plus<distance_fn_value_t<DistanceFn, G>>());
+      Combine&&      combine = plus<distance_fn_value_t<DistanceFn, G>>(),
+      const Alloc&   alloc   = Alloc());

--- a/D3128_Algorithms/src/dijkstra_shortest_paths.hpp
+++ b/D3128_Algorithms/src/dijkstra_shortest_paths.hpp
@@ -5,7 +5,8 @@ template <adjacency_list G,
                                                                        const edge_t<G>&)>,
           class Visitor = empty_visitor,
           class Compare = less<distance_fn_value_t<DistanceFn, G>>,
-          class Combine = plus<distance_fn_value_t<DistanceFn, G>>>
+          class Combine = plus<distance_fn_value_t<DistanceFn, G>>,
+          class Alloc   = allocator<byte>>
 requires distance_fn_for<DistanceFn, G> &&
          predecessor_fn_for<PredecessorFn, G> &&
          basic_edge_weight_function<G, WF, distance_fn_value_t<DistanceFn, G>, Compare, Combine>
@@ -18,4 +19,5 @@ constexpr void dijkstra_shortest_paths(
                        const edge_t<G>& uv) { return distance_fn_value_t<DistanceFn, G>(1); },
       Visitor&&             visitor = empty_visitor(),
       Compare&&             compare = less<distance_fn_value_t<DistanceFn, G>>(),
-      Combine&&             combine = plus<distance_fn_value_t<DistanceFn, G>>());
+      Combine&&             combine = plus<distance_fn_value_t<DistanceFn, G>>(),
+      const Alloc&          alloc   = Alloc());

--- a/D3128_Algorithms/src/dijkstra_shortest_paths_multi.hpp
+++ b/D3128_Algorithms/src/dijkstra_shortest_paths_multi.hpp
@@ -6,18 +6,20 @@ template <adjacency_list G,
                                                                        const edge_t<G>&)>,
           class Visitor = empty_visitor,
           class Compare = less<distance_fn_value_t<DistanceFn, G>>,
-          class Combine = plus<distance_fn_value_t<DistanceFn, G>>>
+          class Combine = plus<distance_fn_value_t<DistanceFn, G>>,
+          class Alloc   = allocator<byte>>
 requires distance_fn_for<DistanceFn, G> &&
          predecessor_fn_for<PredecessorFn, G> &&
          convertible_to<range_value_t<Sources>, vertex_id_t<G>> &&
          basic_edge_weight_function<G, WF, distance_fn_value_t<DistanceFn, G>, Compare, Combine>
 constexpr void dijkstra_shortest_paths(
-      G&&            g,
-      const Sources& sources,
-      DistanceFn&&   distance,
+      G&&             g,
+      const Sources&  sources,
+      DistanceFn&&    distance,
       PredecessorFn&& predecessor,
-      WF&&           weight  = [](const auto&,
+      WF&&            weight  = [](const auto&,
                        const edge_t<G>& uv) { return distance_fn_value_t<DistanceFn, G>(1); },
-      Visitor&&      visitor = empty_visitor(),
-      Compare&&      compare = less<distance_fn_value_t<DistanceFn, G>>(),
-      Combine&&      combine = plus<distance_fn_value_t<DistanceFn, G>>());
+      Visitor&&       visitor = empty_visitor(),
+      Compare&&       compare = less<distance_fn_value_t<DistanceFn, G>>(),
+      Combine&&       combine = plus<distance_fn_value_t<DistanceFn, G>>(),
+      const Alloc&    alloc   = Alloc());

--- a/D3128_Algorithms/src/mst.hpp
+++ b/D3128_Algorithms/src/mst.hpp
@@ -1,22 +1,26 @@
 /*
  * Kruskal's Algorithm
  */
-template <x_index_edgelist_range IELR, x_index_edgelist_range OELR>
-auto kruskal(IELR&& e, OELR&& t);
+template <x_index_edgelist_range IELR, x_index_edgelist_range OELR,
+          class Alloc = allocator<byte>>
+auto kruskal(IELR&& e, OELR&& t, const Alloc& alloc = Alloc());
 
-template <x_index_edgelist_range IELR, x_index_edgelist_range OELR, class CompareOp>
-auto kruskal(IELR&& e, OELR&& t, CompareOp compare);
+template <x_index_edgelist_range IELR, x_index_edgelist_range OELR, class CompareOp,
+          class Alloc = allocator<byte>>
+auto kruskal(IELR&& e, OELR&& t, CompareOp compare, const Alloc& alloc = Alloc());
 
 /*
  * Inplace Kruskal's Algorithm
  */
-template <x_index_edgelist_range IELR, x_index_edgelist_range OELR>
+template <x_index_edgelist_range IELR, x_index_edgelist_range OELR,
+          class Alloc = allocator<byte>>
 requires permutable<iterator_t<IELR>>
-auto inplace_kruskal(IELR&& e, OELR&& t);
+auto inplace_kruskal(IELR&& e, OELR&& t, const Alloc& alloc = Alloc());
 
-template <x_index_edgelist_range IELR, x_index_edgelist_range OELR, class CompareOp>
+template <x_index_edgelist_range IELR, x_index_edgelist_range OELR, class CompareOp,
+          class Alloc = allocator<byte>>
 requires permutable<iterator_t<IELR>>
-auto inplace_kruskal(IELR&& e, OELR&& t, CompareOp compare);
+auto inplace_kruskal(IELR&& e, OELR&& t, CompareOp compare, const Alloc& alloc = Alloc());
 
 /*
  * Prim's Algorithm
@@ -26,7 +30,8 @@ template <adjacency_list G,
           class          PredecessorFn,
           class WF      = function<distance_fn_value_t<WeightFn, G>(const remove_reference_t<G>&,
                                                                       const edge_t<G>&)>,
-          class CompareOp = less<distance_fn_value_t<WeightFn, G>>>
+          class CompareOp = less<distance_fn_value_t<WeightFn, G>>,
+          class Alloc   = allocator<byte>>
 requires distance_fn_for<WeightFn, G> &&
          is_arithmetic_v<distance_fn_value_t<WeightFn, G>> &&
          predecessor_fn_for<PredecessorFn, G> &&
@@ -37,4 +42,5 @@ auto prim(G&&                   g,
           WeightFn&&            weight,
           PredecessorFn&&       predecessor,
           WF&&                  weight_fn = [](const auto& gr, const edge_t<G>& uv) { return edge_value(gr, uv); },
-          CompareOp             compare   = less<distance_fn_value_t<WeightFn, G>>());
+          CompareOp             compare   = less<distance_fn_value_t<WeightFn, G>>(),
+          const Alloc&          alloc     = Alloc());

--- a/D3128_Algorithms/src/tarjan_scc.hpp
+++ b/D3128_Algorithms/src/tarjan_scc.hpp
@@ -1,6 +1,6 @@
 /*
  * Tarjan's Strongly Connected Components
  */
-template <adjacency_list G, class ComponentFn>
+template <adjacency_list G, class ComponentFn, class Alloc = allocator<byte>>
 requires vertex_property_fn_for<ComponentFn, G>
-size_t tarjan_scc(G&& g, ComponentFn&& component);
+size_t tarjan_scc(G&& g, ComponentFn&& component, const Alloc& alloc = Alloc());

--- a/D3128_Algorithms/src/topological_sort.hpp
+++ b/D3128_Algorithms/src/topological_sort.hpp
@@ -1,10 +1,12 @@
 // Single-source topological sort
-template <adjacency_list G, class OutputIterator>
+template <adjacency_list G, class OutputIterator, class Alloc = allocator<byte>>
 requires output_iterator<OutputIterator, vertex_id_t<G>>
 [[nodiscard]] bool
-topological_sort(const G& g, const vertex_id_t<G>& source, OutputIterator result);
+topological_sort(const G& g, const vertex_id_t<G>& source, OutputIterator result,
+                 const Alloc& alloc = Alloc());
 
 // Full-graph topological sort
-template <adjacency_list G, class OutputIterator>
+template <adjacency_list G, class OutputIterator, class Alloc = allocator<byte>>
 requires output_iterator<OutputIterator, vertex_id_t<G>>
-[[nodiscard]] bool topological_sort(const G& g, OutputIterator result);
+[[nodiscard]] bool topological_sort(const G& g, OutputIterator result,
+                                    const Alloc& alloc = Alloc());

--- a/D3128_Algorithms/src/topological_sort_multi.hpp
+++ b/D3128_Algorithms/src/topological_sort_multi.hpp
@@ -1,4 +1,6 @@
-template <adjacency_list G, input_range Sources, class OutputIterator>
+template <adjacency_list G, input_range Sources, class OutputIterator,
+          class Alloc = allocator<byte>>
 requires convertible_to<range_value_t<Sources>, vertex_id_t<G>> &&
          output_iterator<OutputIterator, vertex_id_t<G>>
-[[nodiscard]] bool topological_sort(const G& g, const Sources& sources, OutputIterator result);
+[[nodiscard]] bool topological_sort(const G& g, const Sources& sources, OutputIterator result,
+                                    const Alloc& alloc = Alloc());

--- a/D3128_Algorithms/tex/algorithms.tex
+++ b/D3128_Algorithms/tex/algorithms.tex
@@ -492,6 +492,10 @@ Compute the breadth-first path from one or more \tcode{source} vertices to all r
             \begin{itemize}
                   \item \tcode{dijkstra_shortest_paths} provides extended functionality if \tcode{breadth_first_search} doesn't have
                          enough capability.
+                  \item The optional \lstinline{alloc} parameter supplies an allocator used for
+                        the internal FIFO queue.  Defaults to \tcode{std::allocator<std::byte>}.
+                        Provide a custom allocator (e.g.~a pool allocator) to control the memory
+                        used by the traversal queue.
             \end{itemize}
       %\pnum\errors
 \end{itemdescr}
@@ -582,6 +586,10 @@ Traverse the depth-first path from one or more \tcode{source} vertices to all re
             \begin{itemize}
                   \item Uses iterative DFS with explicit stack to avoid recursion-depth limits.
                   \item Edge iterators are stored on the stack for $\mathcal{O}(1)$ resume after backtracking.
+                  \item The optional \lstinline{alloc} parameter supplies an allocator used for
+                        the internal DFS stack.  Defaults to \tcode{std::allocator<std::byte>}.
+                        Provide a custom allocator (e.g.~a pool allocator) to control the memory
+                        used by the traversal stack.
             \end{itemize}
       %\pnum\errors
 \end{itemdescr}
@@ -661,6 +669,10 @@ A linear ordering of vertices such that for every directed edge (u,v) from verte
             \begin{itemize}
                   \item Duplicate sources do not affect the algorithm's complexity or correctness.
                   \item The full-graph overload visits all vertices regardless of reachability from a single source.
+                  \item The optional \lstinline{alloc} parameter supplies an allocator used for
+                        the internal finish-order vector and DFS stack.  Defaults to
+                        \tcode{std::allocator<std::byte>}.  All three overloads (single-source,
+                        multi-source, full-graph) accept this parameter.
             \end{itemize}
       %\pnum\errors
 \end{itemdescr}
@@ -846,6 +858,10 @@ instead of a binary heap implemented with \tcode{std::priority_queue}.
                         the same way (see §\textit{Vertex Property Function Concepts}).
                   \item Pass \lstinline{_null_predecessor} as \lstinline{predecessor} when predecessor tracking
                         is not needed (avoids storing results).
+                  \item The optional \lstinline{alloc} parameter supplies an allocator used for
+                        the internal priority queue.  Defaults to \tcode{std::allocator<std::byte>}.
+                        Provide a custom allocator (e.g.~a pool allocator) to control the memory
+                        used by the priority queue during traversal.
             \end{itemize}
       %\pnum\errors
 \end{itemdescr}
@@ -948,6 +964,10 @@ giving a small performance improvement with lower memory overhead.
                   \item \tcode{DistanceFn} must satisfy \tcode{distance_fn_for<DistanceFn,G>}.  Wrap a
                         \tcode{std::vector} or \tcode{std::unordered_map} with \tcode{container_value_fn}
                         (see §\textit{Vertex Property Function Concepts}).
+                  \item The optional \lstinline{alloc} parameter supplies an allocator used for
+                        the internal priority queue.  Defaults to \tcode{std::allocator<std::byte>}.
+                        Provide a custom allocator (e.g.~a pool allocator) to control the memory
+                        used by the priority queue during traversal.
             \end{itemize}
       %\pnum\errors
 \end{itemdescr}
@@ -1568,6 +1588,9 @@ rooted at $v$ via back-edges. A vertex $u$ is an articulation point under one of
                         \lstinline{cut_vertices}.
                   \item Disconnected graphs are handled correctly; the outer loop restarts DFS
                         from each unvisited vertex.
+                  \item The optional \lstinline{alloc} parameter supplies an allocator used for
+                        the internal DFS stack and discovery/low-link arrays.  Defaults to
+                        \tcode{std::allocator<std::byte>}.
             \end{itemize}
       %\pnum\errors
 \end{itemdescr}
@@ -1654,6 +1677,9 @@ trivial single-vertex components. Articulation-point vertices appear in more tha
                         from each unvisited vertex.
                   \item The implementation uses iterative DFS with stored edge iterators to avoid
                         recursion-depth limits and $\mathcal{O}(\text{degree})$ re-scans on resume.
+                  \item The optional \lstinline{alloc} parameter supplies an allocator used for
+                        the internal DFS stack, edge stack, and discovery/low-link arrays.  Defaults
+                        to \tcode{std::allocator<std::byte>}.
             \end{itemize}
       %\pnum\errors
 \end{itemdescr}
@@ -1680,7 +1706,7 @@ Find weakly connected components of a graph. Weakly connected components are sub
 
 {
 \small
-     \lstinputlisting[firstline=14,lastline=19]{D3128_Algorithms/src/connected_components.hpp}
+     \lstinputlisting[firstline=17,lastline=19]{D3128_Algorithms/src/connected_components.hpp}
 }
 
 \begin{itemdescr}
@@ -1716,6 +1742,8 @@ Find weakly connected components of a graph. Weakly connected components are sub
                   \item
                         If the maximum component id is \lstinline{num_vertices(g)-1}, each vertex is the sole vertex in its 
                         own connected component.
+                  \item The optional \lstinline{alloc} parameter supplies an allocator used for
+                        the internal DFS stack.  Defaults to \tcode{std::allocator<std::byte>}.
             \end{itemize}
       %\pnum\errors
 \end{itemdescr}
@@ -1746,7 +1774,7 @@ Find strongly connected components of a graph using Kosaraju's algorithm. Strong
 \end{table}
 
 {\small
-      \lstinputlisting[firstline=32, lastline=41]{D3128_Algorithms/src/connected_components.hpp}
+      \lstinputlisting[firstline=35, lastline=43]{D3128_Algorithms/src/connected_components.hpp}
 }
 
 \begin{itemdescr}
@@ -1787,6 +1815,9 @@ Find strongly connected components of a graph using Kosaraju's algorithm. Strong
                   \item
                         If the maximum component id is \lstinline{num_vertices(g)-1}, each vertex is the sole vertex in its 
                         own strongly connected component.
+                  \item The optional \lstinline{alloc} parameter supplies an allocator used for
+                        the internal finish-order vector and DFS stacks.  Defaults to
+                        \tcode{std::allocator<std::byte>}.
             \end{itemize}
       %\pnum\errors
 \end{itemdescr}
@@ -1871,6 +1902,9 @@ directed path from every vertex in the set to every other vertex in the set.
                         strongly connected component (the graph is strongly connected).
                   \item If the return value equals \lstinline{num_vertices(g)}, every vertex
                         is its own SCC (a DAG).
+                  \item The optional \lstinline{alloc} parameter supplies an allocator used for
+                        the internal DFS stack, SCC stack, and discovery/low-link arrays.  Defaults
+                        to \tcode{std::allocator<std::byte>}.
             \end{itemize}
 \end{itemdescr}
 
@@ -2011,7 +2045,7 @@ Find the minimum weight spanning tree of a graph using Kruskal's algorithm.
 \end{table}
 
 {\small
-      \lstinputlisting[firstline=4,lastline=8]{D3128_Algorithms/src/mst.hpp}
+      \lstinputlisting[firstline=4,lastline=10]{D3128_Algorithms/src/mst.hpp}
 }
 \begin{itemdescr}
       \pnum\mandates
@@ -2042,7 +2076,9 @@ Find the minimum weight spanning tree of a graph using Kruskal's algorithm.
                   \item \textbf{Time:} $\mathcal{O}(|E|\log{|E|})$.
                   \item \textbf{Space:} $\mathcal{O}(|E|+|V|)$ auxiliary --- edge copy and union-find.
             \end{itemize}
-      %\pnum\remarks 
+      \pnum\remarks The optional \lstinline{alloc} parameter supplies an allocator used for
+            the internal disjoint-set (union-find) storage.  Defaults to
+            \tcode{std::allocator<std::byte>}.
       %\pnum\errors
 \end{itemdescr}
 
@@ -2068,7 +2104,7 @@ rather than making a copy.  The input range must satisfy \lstinline{permutable<i
 \end{table}
 
 {\small
-      \lstinputlisting[firstline=13,lastline=19]{D3128_Algorithms/src/mst.hpp}
+      \lstinputlisting[firstline=15,lastline=23]{D3128_Algorithms/src/mst.hpp}
 }
 \begin{itemdescr}
       \pnum\mandates
@@ -2104,6 +2140,9 @@ rather than making a copy.  The input range must satisfy \lstinline{permutable<i
             \end{itemize}
       \pnum\remarks The input edge list is modified (sorted).  If the caller needs to
             preserve the original order, use \lstinline{kruskal} instead.
+            The optional \lstinline{alloc} parameter supplies an allocator used for
+            the internal disjoint-set (union-find) storage.  Defaults to
+            \tcode{std::allocator<std::byte>}.
       %\pnum\errors
 \end{itemdescr}
 
@@ -2129,7 +2168,7 @@ Delegates to \lstinline{dijkstra_shortest_paths} with a projecting combine funct
 \end{table}
 
 {\small
-      \lstinputlisting[firstline=24,lastline=40]{D3128_Algorithms/src/mst.hpp}
+      \lstinputlisting[firstline=28,lastline=46]{D3128_Algorithms/src/mst.hpp}
 }
 
 \begin{itemdescr}
@@ -2186,6 +2225,9 @@ Delegates to \lstinline{dijkstra_shortest_paths} with a projecting combine funct
             \end{itemize}
       \pnum\remarks Only produces a spanning tree for the connected component containing \lstinline{seed}.
             For disconnected graphs, call \lstinline{prim} once per component with a seed vertex from each component.
+            The optional \lstinline{alloc} parameter supplies an allocator used for
+            the internal priority queue (forwarded to \lstinline{dijkstra_shortest_paths}).
+            Defaults to \tcode{std::allocator<std::byte>}.
       %\pnum\errors
 \end{itemdescr}
 


### PR DESCRIPTION
Add Alloc template parameter (defaulting to std::allocator<byte>) and const Alloc& alloc parameter to all algorithms that use internal dynamic storage:

Traversal:
- breadth_first_search (single- and multi-source)
- depth_first_search
- topological_sort (single-source, multi-source, full-graph)

Shortest paths:
- dijkstra_shortest_paths (single- and multi-source)
- dijkstra_shortest_distances (single- and multi-source)

Components:
- articulation_points
- biconnected_components
- connected_components
- kosaraju (both overloads)
- tarjan_scc

MST:
- kruskal (both overloads)
- inplace_kruskal (both overloads)
- prim

Update algorithms.tex: add alloc remarks to each affected algorithm section and fix lstinputlisting line ranges for connected_components.hpp and mst.hpp after synopsis expansion.